### PR TITLE
added ciphers to HTTPS requests, newer versions of node fail if they are not set

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -5,8 +5,13 @@ const cheerio = require('cheerio');
 
 module.exports = orderId => {
   return new Promise((resolve, reject) => {
-    const url = `https://www.chilexpress.cl/Views/ChilexpressCL/Resultado-busqueda.aspx?DATA=${orderId}`;
-    https.get(url, res => {
+    const opts = {
+      hostname: 'www.chilexpress.cl',
+      path: `/Views/ChilexpressCL/Resultado-busqueda.aspx?DATA=${orderId}`,
+      port: 443,
+      ciphers: 'ECDHE-RSA-AES256-SHA:AES256-SHA:RC4-SHA:RC4:HIGH:!MD5:!aNULL:!EDH:!AESGCM'
+    };
+    https.get(opts, res => {
       if (res.statusCode !== 200) {
         res.resume();
         reject(new Error(`Request Failed. Status Code: ${res.statusCode}`));


### PR DESCRIPTION
Hola!

Si los ciphers no estaban seteados, por temas de seguridad las versiones nuevas de node se niegan a hacer conexiones HTTPS al parecer, agregandolos se soluciona el tema.

Los tests pasaron en v6.9.1 y v4.4, antes solo funcionaba en v4.4

Saludos! 